### PR TITLE
live update pending DFT rewards on each block

### DIFF
--- a/src/hooks/useAnyStake.ts
+++ b/src/hooks/useAnyStake.ts
@@ -1,7 +1,7 @@
 import BigNumber from "bignumber.js";
 import { Pools } from "constants/pools";
 import DeFiat from "contexts/DeFiat";
-import { getTokenPrice, getOracle, getDeFiatAddress, getAnyStakeContract, pendingAnyStake, getTetherAddress, totalStakedAnyStake, totalValueStakedAllPoolsAnyStake, totalPendingAnyStake, totalValueStakedAnyStake, totalPoolsStakedAnyStake } from "defiat";
+import { getTokenPrice, getOracle, getDeFiatAddress, getAnyStakeContract, pendingAnyStake, getTetherAddress, totalStakedAnyStake, totalValueStakedAllPoolsAnyStake, totalPendingAnyStake, totalValueStakedAnyStake, totalPoolsStakedAnyStake, totalPendingVirtualAnyStake } from "defiat";
 import { useEffect, useMemo } from "react";
 import { useCallback, useState } from "react";
 import { useWallet } from "use-wallet";
@@ -35,7 +35,7 @@ export const useAnyStake = () => {
     const values = await Promise.all([
       getTokenPrice(Oracle, getDeFiatAddress(DeFiat)),
       getTokenPrice(Oracle, getTetherAddress(DeFiat)),
-      totalPendingAnyStake(AnyStake, Pools[chainId], account),
+      totalPendingVirtualAnyStake(AnyStake, Pools[chainId], account, block),
       totalValueStakedAllPoolsAnyStake(Oracle, DeFiat, AnyStake, Pools[chainId]),
       totalValueStakedAnyStake(Oracle, DeFiat, AnyStake, Pools[chainId], account),
       totalPoolsStakedAnyStake(AnyStake, Pools[chainId], account)
@@ -52,7 +52,7 @@ export const useAnyStake = () => {
       totalValueStaked: getDisplayBalance(totalValueStaked),
       totalStakes: values[5]
     });
-  }, [account, ethereum, DeFiat, Oracle, AnyStake]);
+  }, [account, ethereum, DeFiat, Oracle, AnyStake, block]);
 
   useEffect(() => {
     if (!!account && !!DeFiat) {

--- a/src/hooks/usePool.ts
+++ b/src/hooks/usePool.ts
@@ -14,6 +14,7 @@ import {
   withdrawAnyStake,
   getTetherAddress,
   vipAmountAnyStake,
+  pendingVirtualAnyStake,
 } from "defiat";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useWallet } from "use-wallet";
@@ -82,7 +83,8 @@ export const usePool = (pid: number) => {
       getTokenPrice(Oracle, Pools[chainId][pid].address),
       getTokenPrice(Oracle, getTetherAddress(DeFiat)),
       vipAmountAnyStake(AnyStake, pid),
-      stakedAnyStake(AnyStake, 0, account)
+      stakedAnyStake(AnyStake, 0, account),
+      pendingVirtualAnyStake(AnyStake, pid, account, block)
       // getTokenPrice(Oracle, getDeFiatAddress(DeFiat)),
     ]);
 
@@ -98,11 +100,11 @@ export const usePool = (pid: number) => {
       tokenPrice,
       totalValueLocked,
       stakedBalance: values[3],
-      pendingRewards: values[4],
+      pendingRewards: values[9],
       vipAmount: values[7],
       vipAmountUser: values[8]
     });
-  }, [account, chainId, pid, ethereum, Oracle, AnyStake, DeFiat]);
+  }, [account, chainId, pid, ethereum, Oracle, AnyStake, DeFiat, block]);
 
   useEffect(() => {
     if (!!account && !!DeFiat) {

--- a/src/hooks/useRegulator.ts
+++ b/src/hooks/useRegulator.ts
@@ -17,6 +17,7 @@ import {
   getVaultContract,
   buybackRegulator,
   isAbovePeg,
+  pendingTotalRegulator,
 } from "defiat";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useWallet } from "use-wallet";
@@ -88,12 +89,14 @@ export const useRegulator = () => {
       getRegulatorApr(Oracle, DeFiat, Vault, Regulator),
       buybackRegulator(Regulator),
       isAbovePeg(Regulator),
+      pendingTotalRegulator(Regulator),
     ]);
 
     const tokenPrice = values[7].multipliedBy(1e18).dividedBy(values[6]);
     const pointsPrice = values[7].multipliedBy(1e18).dividedBy(values[5]);
     const totalValueLocked = pointsPrice.times(values[1]).div(1e18);
     const apr = values[8].dividedBy(1e18).decimalPlaces(2).toString();
+    const pendingRewards = values[1].isZero() ? values[4] : values[4].plus(values[3].dividedBy(values[1]).multipliedBy(values[11]));
 
     setData({
       totalLocked: values[1],
@@ -103,7 +106,7 @@ export const useRegulator = () => {
       tokenBalance: values[0],
       peg: +values[2] / 10,
       ratio: tokenPrice.div(pointsPrice),
-      pendingRewards: values[4],
+      pendingRewards: pendingRewards,
       stakedBalance: values[3],
       apr: apr,
       buybackBalance: values[9],


### PR DESCRIPTION
pendingVirtualAnyStake added which is used to calculate current pending rewards to see them update live.
This updates rewards as if the updatepool() call is run every block.

Might need to add a flag later so a user can decide if he wants live updates or static updates since it consumes more resources
